### PR TITLE
Replace RCHPlacement with RCHRecommendedPlacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Basic SDK Usage (Objective-C):
     [[RCHSDK defaultClient] sendRequest:[builder build] success:^(id responseObject) {
 
         RCHPlacementsResult *result = responseObject;
-        RCHPlacement *placement = result.placements[0];
+        RCHRecommendedPlacement *placement = result.placements[0];
         product = placement.recommendedProducts[0];
 
         [product trackProductView];


### PR DESCRIPTION
I would like to fix README example because there is a typo and the current example cannot compile because of it.

My change is to replace RCHPlacement with RCHRecommendedPlacement to access recommendedProducts property successfully.
